### PR TITLE
Perl module version check in Perl script

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,6 @@ We have not yet extensively tested against different aligner settings, but we sp
 
 The repeat expansion loci are specified in a tab delimited file. 
 This is available in the R [exSTRa package](https://github.com/bahlolab/exSTRa) under `inst/extdata/repeat_expansion_disorders.txt`.
-Either use the file where the R package is installed, or download directly from https://raw.githubusercontent.com/bahlolab/exSTRa/master/inst/extdata/repeat_expansion_disorders.txt.
+Either use the file where the R package is installed, or download directly: [repeat_expansion_disorders.txt](https://raw.githubusercontent.com/bahlolab/exSTRa/master/inst/extdata/repeat_expansion_disorders.txt).
 
 See [`examples/run_strexpansion_score.sh`](examples/run_strexpansion_score.sh) for an example of running the script [`bin/exSTRa_score.pl`](bin/exSTRa_score.pl) that can be modified to your data.

--- a/bin/exSTRa_score.pl
+++ b/bin/exSTRa_score.pl
@@ -21,7 +21,7 @@ perl exSTRa_score.pl --by_alignment $bahlolab_db/hg19/standard_gatk/hg19.fa ../d
 use 5.014;
 use strict 'vars';
 use warnings; 
-use Bio::STR::exSTRa; 
+use Bio::STR::exSTRa 1.0.0; 
 use Bio::DB::HTS;
 use autodie; 
 use Getopt::Long;


### PR DESCRIPTION
The Perl script bin/exSTRa_score.pl now explicitly checks the Perl module version. May save users from more cryptic error messages.