### PR TITLE
Allow usage of UCSC Simple Repeats track

### DIFF
--- a/bin/exSTRa_score.pl
+++ b/bin/exSTRa_score.pl
@@ -21,7 +21,7 @@ perl exSTRa_score.pl --by_alignment $bahlolab_db/hg19/standard_gatk/hg19.fa ../d
 use 5.014;
 use strict 'vars';
 use warnings; 
-use Bio::STR::exSTRa 1.0.0; 
+use Bio::STR::exSTRa 1.0.1; 
 use Bio::DB::HTS;
 use autodie; 
 use Getopt::Long;

--- a/lib/Bio/STR/exSTRa.pm
+++ b/lib/Bio/STR/exSTRa.pm
@@ -378,7 +378,7 @@ sub read_str_database_UCSC_TRF {
     while(<STRDB>) {
         chomp;
         my @line = split(/\t/);
-        my $str = STR->new(compound_strs_allowed => $self->compound_strs_allowed);
+        my $str = exSTRa->new(compound_strs_allowed => $self->compound_strs_allowed);
         ++$line[$coli{'chromStart'}]; # account for 0-based coordinates
         foreach my $internal (keys %data_2_internal) {
             $str->{$data_2_internal{$internal}} = $line[$coli{$internal}];

--- a/lib/Bio/STR/exSTRa.pm
+++ b/lib/Bio/STR/exSTRa.pm
@@ -21,7 +21,7 @@ use Carp;
 our(@ISA, @EXPORT, @EXPORT_OK, %EXPORT_TAGS, $VERSION);
 
 use Exporter; 
-$VERSION = 1.0.0;
+$VERSION = 1.0.1;
 @ISA = qw(Exporter); 
 
 @EXPORT     = qw ();


### PR DESCRIPTION
A small bug fix so this actually works. The UCSC Simple Repeats track is derived from Tandem Repeats Finder. 

> G. Benson, "Tandem repeats finder: a program to analyze DNA sequences", Nucleic Acids Research (1999) Vol. 27, No. 2, pp. 573-580.