### PR TITLE
v1.0.3 bug fixes of sample name determination

### DIFF
--- a/lib/Bio/STR/exSTRa.pm
+++ b/lib/Bio/STR/exSTRa.pm
@@ -635,8 +635,12 @@ sub read_bams_array {
             -bam => $bam_file,
             -autoindex => 1,
         );
-        $bam->header->text =~ /\tSM:([^\t]+)\t/;
-        my $sample_name = $1;
+        my $sample_name;
+        if($bam->header->text =~ /\@RG.*\tSM:([^\t\n]+)[\t\n]/) {
+            $sample_name = $1;
+        } else {
+            $sample_name = $bam_file;
+        }
         $self->read_bams({ $sample_name => $bam_file }, @_);
     }
 }

--- a/lib/Bio/STR/exSTRa.pm
+++ b/lib/Bio/STR/exSTRa.pm
@@ -21,7 +21,7 @@ use Carp;
 our(@ISA, @EXPORT, @EXPORT_OK, %EXPORT_TAGS, $VERSION);
 
 use Exporter; 
-$VERSION = 1.0.2;
+$VERSION = 1.0.3;
 @ISA = qw(Exporter); 
 
 @EXPORT     = qw ();
@@ -636,7 +636,7 @@ sub read_bams_array {
             -autoindex => 1,
         );
         my $sample_name;
-        if($bam->header->text =~ /\@RG.*\tSM:([^\t\n]+)[\t\n]/) {
+        if($bam->header->text =~ /\@RG.*\tSM:([^\t\n]+)/) {
             $sample_name = $1;
         } else {
             $sample_name = $bam_file;


### PR DESCRIPTION
The SM tag on the `@RG` line now works correctly when it is the last tag on the line. Previously, this was capturing the newline and including at least the start of the next line. 

If a BAM file with no @RG line, or RG line has no SM tag, then the sample name now becomes the file path.

We also enforced that the line starts with `@RG`. No longer require the tag ends with a tab or newline, but regex rules should ensure we match until one of these characters; this means that if no newline ends the header then this will cause no bug (theoretical possibility, and may have no effect whatsoever).