### PR TITLE
Release v1.1.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,9 +8,9 @@ perl:
   - "5.14"
 
 allow_failures:
-  perl:
-    - "5.18"
-    - "5.14"
+  - perl: "5.18"
+  - perl: "5.14"
+
 os:
   - linux
 
@@ -26,3 +26,6 @@ notifications:
   email:
     on_success: always
     on_failure: always
+
+jobs:
+  fast_finish: true

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,11 @@ perl:
   - "5.22"
   - "5.18"
   - "5.14"
-  
+
+allow_failures:
+  perl:
+    - "5.18"
+    - "5.14"
 os:
   - linux
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,9 +7,10 @@ perl:
   - "5.18"
   - "5.14"
 
-allow_failures:
-  - perl: "5.18"
-  - perl: "5.14"
+matrix:
+  allow_failures:
+    - perl: "5.18"
+    - perl: "5.14"
 
 os:
   - linux

--- a/README.md
+++ b/README.md
@@ -54,8 +54,8 @@ We have not yet extensively tested against different aligner settings, but we sp
 # Script to process BAM/CRAM files
 
 The repeat expansion loci are specified in a tab delimited file. 
-This is available in the R [exSTRa package](https://github.com/bahlolab/exSTRa) under `inst/extdata/repeat_expansion_disorders.txt`.
-Either use the file where the R package is installed, or download directly: [repeat_expansion_disorders.txt](https://raw.githubusercontent.com/bahlolab/exSTRa/master/inst/extdata/repeat_expansion_disorders.txt).
+This is available in the R [exSTRa package](https://github.com/bahlolab/exSTRa) under `inst/extdata/repeat_expansion_disorders_hg19.txt` or `inst/extdata/repeat_expansion_disorders_grch37.txt`, with hg38 and GRCh38 files coming soon.
+Either use the file where the R package is installed, or download directly: [repeat_expansion_disorders_hg19.txt](https://raw.githubusercontent.com/bahlolab/exSTRa/master/inst/extdata/repeat_expansion_disorders_hg19.txt) or [repeat_expansion_disorders_grch37.txt](https://raw.githubusercontent.com/bahlolab/exSTRa/master/inst/extdata/repeat_expansion_disorders_grch37.txt).
 
 See [`examples/run_strexpansion_score.sh`](examples/run_strexpansion_score.sh) for an example of running the script [`bin/exSTRa_score.pl`](bin/exSTRa_score.pl) that can be modified to your data. 
 The Docker container has `exSTRa_score.pl` as an executable command. 

--- a/README.md
+++ b/README.md
@@ -27,13 +27,22 @@ https://hub.docker.com/r/ricktankard/bio-str-exstra
 
 Install as a module:
 
+    # Install Bio::Perl if not installed already (assumes CPAN Minus is available)
+    cpanm 'Bio::Perl'
+
     perl Build.PL
+    ./Build installdeps # This is as suggested by the previous command - the command for you to run may vary.
     ./Build
     ./Build test
     ./Build install
 
 If you do not have write access to the Perl module directory, you may need to use the local::lib module. 
 In some circumstances these commands may still not work, and you may need to seek help on Perl's Module::Build. 
+
+If Bio::DB::HTS has trouble installing, first check that [htslib](https://github.com/samtools/htslib) is fully installed. 
+I have also had success installing it (after installing Bio::Perl) with this command:
+
+    bash <(curl https://raw.githubusercontent.com/Ensembl/Bio-DB-HTS/master/scripts/build_options.sh) "git clone --branch master --depth=1 https://github.com/Ensembl/Bio-DB-HTS.git" "BUILD_LOCAL_INSTALLED_HTSLIB"
 
 # Preparation of BAM files
 

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ https://hub.docker.com/r/ricktankard/bio-str-exstra
 
 Install as a module:
 
-    # Assumes htslib is already installed. See Install Requirements section above.
+    # Assumes htslib is already installed. See Install Requirements section above, or below for some installation tips.
 
     # Install Bio::Perl if not installed already (assumes CPAN Minus is available)
     cpanm 'Bio::Perl'
@@ -41,8 +41,8 @@ Install as a module:
 If you do not have write access to the Perl module directory, you may need to use the local::lib module. 
 In some circumstances these commands may still not work, and you may need to seek help on Perl's Module::Build. 
 
-If Bio::DB::HTS has trouble installing, first check that [htslib](https://github.com/samtools/htslib) is fully installed. 
-I have also had success installing it (after installing Bio::Perl) with this command:
+If Bio::DB::HTS has trouble installing, first check that [htslib](https://github.com/samtools/htslib) is properly installed including lib paths. 
+For local installs, we have had success installing it (after installing Bio::Perl) with the following command:
 
     bash <(curl https://raw.githubusercontent.com/Ensembl/Bio-DB-HTS/master/scripts/build_options.sh) "git clone --branch master --depth=1 https://github.com/Ensembl/Bio-DB-HTS.git" "BUILD_LOCAL_INSTALLED_HTSLIB"
 

--- a/README.md
+++ b/README.md
@@ -9,9 +9,9 @@ For details of the purpose of this software please see https://github.com/bahlol
 
 **Perl 5.14.1**
 
-Required CPAN modules can be obtained by instructions from the `perl Build.PL` command. 
-
 The CPAN module Bio::DB::HTS requires [htslib](https://github.com/samtools/htslib), that may be easier to install separately, or to install [Bio::DB::HTS from Github](https://github.com/Ensembl/Bio-DB-HTS) with one of the options in the `scripts/build_options.sh` script. 
+
+Required CPAN modules can be obtained by instructions from the `perl Build.PL` command. 
 
 # Setup 
 
@@ -26,6 +26,8 @@ https://hub.docker.com/r/ricktankard/bio-str-exstra
 ## Perl library install
 
 Install as a module:
+
+    # Assumes htslib is already installed. See Install Requirements section above.
 
     # Install Bio::Perl if not installed already (assumes CPAN Minus is available)
     cpanm 'Bio::Perl'

--- a/bin/exSTRa_score.pl
+++ b/bin/exSTRa_score.pl
@@ -91,8 +91,8 @@ if($repeat_database =~ /\.xlsx$/) {
         warn "Tab delimited file of named loci $repeat_database\n";
         # Find start and end header names.
         # There should only be one of each.
-        my @start_names = grep { /start$/ } @head;
-        my @end_names = grep { /end$/ } @head;
+        my @start_names = grep { /start$/ } @heads;
+        my @end_names = grep { /end$/ } @heads;
         if(@start_names != 1 && @end_names != 1) {
             die "There was not exactly one '*start' column and '*end' column.\n" .
             "Note that any column name that ends with 'start' or 'end' respectively will match.\n" .

--- a/bin/exSTRa_score.pl
+++ b/bin/exSTRa_score.pl
@@ -89,10 +89,22 @@ if($repeat_database =~ /\.xlsx$/) {
 
     if($is_named_loci) {
         warn "Tab delimited file of named loci $repeat_database\n";
+        # Find start and end header names.
+        # There should only be one of each.
+        my @start_names = grep { /start$/ } @head;
+        my @end_names = grep { /end$/ } @head;
+        if(@start_names != 1 && @end_names != 1) {
+            die "There was not exactly one '*start' column and '*end' column.\n" .
+            "Note that any column name that ends with 'start' or 'end' respectively will match.\n" .
+            "start columns: " . join(", ", @start_names) .
+            "end columns: " . join(", ", @end_names) .
+            "\n";
+        }
+
         $strs->read_str_database_tsv($repeat_database, 
            (    chrom   => 'chrom', 
-                start  => 'hg19_start',
-                end     => 'hg19_end', 
+                start  => $start_names[0],
+                end     => $end_names[0],
                 repeat_unit => 'motif',
                 per_match => 'perMatch',
                 per_indel => 'perIndel',
@@ -103,7 +115,8 @@ if($repeat_database =~ /\.xlsx$/) {
                 # read_detect_size => 'read_detect_size',
                 #stable_repeats => 'Stable repeat number',
                 #unstable_repeats => 'Unstable repeat number',
-           ) );
+           )
+        );
         $input_type = 'named';
     } else {
         # UCSC Simple Repeat style
@@ -163,4 +176,3 @@ sub give_seq_counts {
 
 
 }
-

--- a/bin/exSTRa_score.pl
+++ b/bin/exSTRa_score.pl
@@ -93,11 +93,11 @@ if($repeat_database =~ /\.xlsx$/) {
         # There should only be one of each.
         my @start_names = grep { /start$/ } @heads;
         my @end_names = grep { /end$/ } @heads;
-        if(@start_names != 1 && @end_names != 1) {
+        if(@start_names != 1 || @end_names != 1) {
             die "There was not exactly one '*start' column and '*end' column.\n" .
-            "Note that any column name that ends with 'start' or 'end' respectively will match.\n" .
-            "start columns: " . join(", ", @start_names) .
-            "end columns: " . join(", ", @end_names) .
+            "Note that any column name that ends with 'start' or 'end' respectively will match." .
+            "\nstart columns: " . join(", ", @start_names) .
+            "\nend columns: " . join(", ", @end_names) .
             "\n";
         }
 

--- a/bin/exSTRa_score.pl
+++ b/bin/exSTRa_score.pl
@@ -5,6 +5,8 @@ Extracting important information from aligned reads with respect
 to the STR expansion disease loci. Counts the number of repeated bases 
 in reads found. 
 
+version 1.1.0
+
 Usage: 
 perl exSTRa_score.pl $bahlolab_db/hg19/standard_gatk/hg19.fa ../../../disorders/repeat_disorders.txt sample.bam [sample2.bam] [...]
 

--- a/examples/run_strexpansion_score.sh
+++ b/examples/run_strexpansion_score.sh
@@ -18,9 +18,6 @@ repeat_database=path/to/repeat_expansion_disorders_hg19.txt
 # Reference FASTA file, the same reference as the BAM files and repeat_database:
 reference=path/to/hg19.fa
 
-# exSTRa_score.pl path
-exstra_score="bin/exSTRa_score.pl"
-
 ### Running ###
 mkdir -p $(dirname $output)
 

--- a/examples/run_strexpansion_score.sh
+++ b/examples/run_strexpansion_score.sh
@@ -13,9 +13,9 @@ output=output/exSTRa_scores.txt
 
 # As provided from the R exSTRa package (https://github.com/bahlolab/exSTRa).
 # Check that the reference matches your BAM files.
-repeat_database=path/to/repeat_expansion_disorders.txt
+repeat_database=path/to/repeat_expansion_disorders_hg19.txt
 
-# Reference FASTA file, the same as BAM files:
+# Reference FASTA file, the same reference as the BAM files and repeat_database:
 reference=path/to/hg19.fa
 
 # exSTRa_score.pl path
@@ -24,8 +24,8 @@ exstra_score="bin/exSTRa_score.pl"
 ### Running ###
 mkdir -p $(dirname $output)
 
-# Please set the correct path for the exSTRa_score.pl script
-perl "$exstra_score" \
+# If exSTRa_score.pl script is not available in your PATH, you may instead use: perl path/to/exSTRa_score.pl
+exSTRa_score.pl \
     "$reference" \
     "$repeat_database" \
     $bam_glob \

--- a/lib/Bio/STR/exSTRa.pm
+++ b/lib/Bio/STR/exSTRa.pm
@@ -21,7 +21,7 @@ use Carp;
 our(@ISA, @EXPORT, @EXPORT_OK, %EXPORT_TAGS, $VERSION);
 
 use Exporter; 
-$VERSION = 1.0.3;
+$VERSION = 1.1.0;
 @ISA = qw(Exporter); 
 
 @EXPORT     = qw ();


### PR DESCRIPTION
Allows repeat database to use a wider range of names for the repeat start and end. Specifically, the names now just have match the globs: *start and *end. Note that exactly one column must match for each. 
For example we can now use "start", "hg19_start", "hg38_start", "foobar_start" and more.

Travis CI builds are now allowed to fail for Perl 5.14 and 5.18. They used to work, but no longer do :(

Installation instructions include a few more tips. 